### PR TITLE
limit the altitude due it multiplies twice and generated a big area

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -52,7 +52,11 @@ end
 
 function rspawn:get_positions_for(pos, radius)
     local breadth = radius
-    local altitude = radius*2
+    local altitude = water_level + radius
+
+    if rspawn.spawnanywhere then
+        altitude = radius
+    end
 
     local pos1 = {x=pos.x-breadth, y=pos.y, z=pos.z-breadth}
     local pos2 = {x=pos.x+breadth, y=pos.y+altitude, z=pos.z+breadth}


### PR DESCRIPTION
* just use a altitude of same area, above water if spawn anywhere is disable
* it generated too much counts, so we must limit the `altitude`..
* old code just multiplice the ratius in altitude..
* ...that will make the `find_nodes_in_area` search a big amount of area in air:
* closed closes https://codeberg.org/minenux/spawnnew/issues/7
* closed closes https://github.com/taikedz-mt/rspawn/issues/8