### PR TITLE
WIP: Fixed exhaustion bug bigservers

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -165,15 +165,17 @@ function rspawn:set_newplayer_spawn(player, attempts)
             rspawn:set_player_spawn(playername, newpos)
 
         else
+            local fixedpos = spawn:genpos()
+            rspawn:set_player_spawn(playernamer, fixedpos)
+
             -- We did not get a new position
-            
             if rspawn.kick_on_fail or attempts <= 0 then
                 minetest.kick_player(playername, "No personalized spawn points available - please try again later.")
 
             else
-                minetest.chat_send_player(playername, "Could not get custom spawn! Retrying in "..rspawn.gen_frequency.." seconds")
-                minetest.chat_send_player(rspawn.admin, "Exhausted spawns! Could not spawn "..playername)
-                minetest.log("warning", "rspawn -- Exhausted spawns! Could not spawn "..playername)
+                minetest.chat_send_player(playername, "Could not get custom spawn! Used fixed one and retrying in "..rspawn.gen_frequency.." seconds")
+                minetest.chat_send_player(rspawn.admin, "Exhausted spawns! Could not spawn "..playername.." so used fixed one")
+                minetest.log("warning", "rspawn -- Exhausted spawns! Could not spawn "..playername.." so used fixed one")
 
                 minetest.after(rspawn.gen_frequency, function()
                     rspawn:set_newplayer_spawn(player, attempts-1)
@@ -225,6 +227,7 @@ minetest.register_on_respawnplayer(function(player)
         return true
     else
         minetest.chat_send_player(name, "Failed to find your spawn point!")
+        minetest.chat_send_player(rspawn.admin, "Failed spawns! Could not spawn "..name)
         minetest.log("warning", "rspawn -- Could not find spawn point for "..name)
         return false
     end

--- a/init.lua
+++ b/init.lua
@@ -165,14 +165,14 @@ function rspawn:set_newplayer_spawn(player, attempts)
             rspawn:set_player_spawn(playername, newpos)
 
         else
-            local fixedpos = spawn:genpos()
-            rspawn:set_player_spawn(playernamer, fixedpos)
-
             -- We did not get a new position
             if rspawn.kick_on_fail or attempts <= 0 then
                 minetest.kick_player(playername, "No personalized spawn points available - please try again later.")
 
             else
+                local fixedpos = spawn:genpos()
+                 rspawn:set_player_spawn(playernamer, fixedpos)
+
                 minetest.chat_send_player(playername, "Could not get custom spawn! Used fixed one and retrying in "..rspawn.gen_frequency.." seconds")
                 minetest.chat_send_player(rspawn.admin, "Exhausted spawns! Could not spawn "..playername.." so used fixed one")
                 minetest.log("warning", "rspawn -- Exhausted spawns! Could not spawn "..playername.." so used fixed one")

--- a/init.lua
+++ b/init.lua
@@ -90,15 +90,22 @@ function rspawn:newspawn(pos, radius)
         under = minetest.registered_nodes[under]
         over = minetest.registered_nodes[over]
 
-        if under.walkable
-         and not over.walkable
-         and not minetest.is_protected(anode, "")
-         and not (under.groups and under.groups.leaves ) -- no spawning on treetops!
-         and daylight_above(7, anode) then
-            if under.buildable_to then
-                validnodes[#validnodes+1] = {x=anode.x, y=anode.y-1, z=anode.z}
-            else
-                validnodes[#validnodes+1] = anode
+        if under == nil or over == nil then
+            -- `under` or `over` could be nil if a mod that defined that node was removed.
+            -- Not something this mod can resolve, and so we just ignore it.
+            rspawn:debug("Found an undefined node around "..minetest.pos_to_string(anode))
+
+        else
+            if under.walkable
+             and not over.walkable
+             and not minetest.is_protected(anode, "")
+             and not (under.groups and under.groups.leaves ) -- no spawning on treetops!
+             and daylight_above(7, anode) then
+                if under.buildable_to then
+                    validnodes[#validnodes+1] = {x=anode.x, y=anode.y-1, z=anode.z}
+                else
+                    validnodes[#validnodes+1] = anode
+                end
             end
         end
     end

--- a/lua/pregeneration.lua
+++ b/lua/pregeneration.lua
@@ -35,8 +35,9 @@ local function push_new_spawn()
                 rspawn:debug("Generated "..minetest.pos_to_string(newpos))
                 set_pgen(len_pgen()+1, newpos )
             else
-                rspawn:debug("Failed to generate new spawn point to push")
-                minetest.chat_send_player(rspawn.admin, "Failed to generate new spawn")
+                rspawn:debug("Failed to generate new spawn point to push, using predefined generated")
+                set_pgen(len_pgen()+1, random_pos )
+                minetest.chat_send_player(rspawn.admin, "Failed to generate new spawn, using predefined generated")
             end
 
             rspawn:forceload_free_blocks_in(pos1, pos2)


### PR DESCRIPTION
Set fixed pos to failed attemps of pregeneration of spawns
    
* when players join and there's no spawns, used the predefined one as genpos
* also fixeds exhausted spawns so used the genpos already predefined
* this solves the bug that players cannot do anything at server join
* Fixed closes close https://github.com/taikedz-mt/rspawn/issues/14
* Tested on sub-nasa server for a while.. i will report feedback here